### PR TITLE
adapt regex to fit current nm output

### DIFF
--- a/cosy.py
+++ b/cosy.py
@@ -162,7 +162,7 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
     c = re.compile(r"(?P<addr>[0-9a-f]+) "
                    r"(?P<type>[tbdTDB]) "
                    r"(?P<sym>[0-9a-zA-Z_$.]+)\s+"
-                   r"(.+/)?"
+                   r"(.*/)?"
                    r"("
                    r"{appdir}|"
                    r"{riot_base}|"


### PR DESCRIPTION
To be honest: I don't remember the exact cause for this change that I originally proposed two years ago. Apparently somehow the output format of nm has changed on my machine and the new regex should work with both versions.