### PR TITLE
Add an app category in Cozy

### DIFF
--- a/cosy.py
+++ b/cosy.py
@@ -166,20 +166,19 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
                    r"(?P<sym>[0-9a-zA-Z_$.]+)\s+"
                    r"(.*/)?"
                    r"("
-                   r"{appdir}|"
                    r"{riot_base}|"
                    r".cargo/registry/src/[^/]+|"
                    r".cargo/git/checkouts|"
                    r"/rustc/[0-9a-f]+/?/library|"
                    r"ip-over-ble_experiments|"  # HACK...
-                   r"{appdir}/.*bin/pkg"
+                   r"RIOT/app/.*bin/pkg"
                    r")/"
                    r"(?P<path>.+)/"
                    r"(?P<file>[0-9a-zA-Z_-]+\.(c|h|rs)):"
-                   r"(?P<line>\d+)$".format(riot_base=riot_base,
-                                            appdir=appdir))
+                   r"(?P<line>\d+)$".format(riot_base=riot_base))
     for line in dump.splitlines():
-        m = c.match(line.decode("utf-8"))
+        line = line.decode("utf-8").replace(appdir, "RIOT/app")
+        m = c.match(line)
         if m:
             d = {'arcv': '', 'obj': '', 'size': -1, 'alias': []}
             d.update(m.groupdict())

--- a/root/sunburst.js
+++ b/root/sunburst.js
@@ -30,6 +30,7 @@ var b = {
 
 // Mapping of step names to colors.
 var colors = {
+  "app": "#d98b8f",
   "core": "#a173d1",
   "cpu": "#7b615c",
   "boards": "#de783b",


### PR DESCRIPTION
This pull request adds an app category in cozy. The app category is for any files that are inside the directory of the RIOT application. This allows to have a color for all the code that is in the application folder.
Another addition is that application that are not in a subdirectory of the RIOT folder are now correctly regrouped (the files were put in the unspecified directory).

Without the modification:
![image](https://github.com/user-attachments/assets/59a1c253-b50d-41b8-96dc-c0268f71b687)

With the modification:
![image](https://github.com/user-attachments/assets/436aff30-0443-42d4-88a3-65bc218f1960)


More on the modification:
- ` r"((?P<path>.+)/)?"` → This make the path optional. Without the pull request, files that are in the appdir(ectory) are not detected as being in the appdir, because the line of code required the files to be in a subfolder of the appdir.

 