### PR TITLE
Patches from RIOT

### DIFF
--- a/cosy.py
+++ b/cosy.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from os import path
+from os import path, environ
 from pathlib import Path
 import argparse
 import re
@@ -156,6 +156,8 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
 
     rbase.append("RIOT")
     rbase.append("riotbuild/riotbase")
+    if "BUILD_DIR" in environ:
+        rbase.append(environ["BUILD_DIR"])
     riot_base = "|".join([f'{p}/build|{p}' for p in rbase])
 
     c = re.compile(r"(?P<addr>[0-9a-f]+) "

--- a/cosy.py
+++ b/cosy.py
@@ -153,9 +153,9 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
     rbase = ["riotbuild/riotproject"]
     if riot_base:
         rbase.append(riot_base.strip("/"))
-    else:
-        rbase.append("RIOT")
-        rbase.append("riotbuild/riotbase")
+
+    rbase.append("RIOT")
+    rbase.append("riotbuild/riotbase")
     riot_base = "|".join([f'{p}/build|{p}' for p in rbase])
 
     c = re.compile(r"(?P<addr>[0-9a-f]+) "


### PR DESCRIPTION
This applies the remaining two patches from RIOT:

* patches/0002-parse_elffile-fix-riot_base.patch
* patches/0003-take-BUILD_DIR-environment-variable-into-account.patch

Both look plausible, and I definitely remember having needed to apply 0002 in practice.

Once those are in, we can do a round of patch removal and cosy updating in RIOT.

@mguetschow may have an easy time ACKing this :-)