### PR TITLE
README: Point to canonical URI to make issue references resolvable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ Python tool analyzing memory usage and distribution in .elf files
 
 The project was originally developed [by Hauke Petersen](https://github.com/haukepetersen/cosy);
 the [RIOT project](https://riot-os.org/) is maintaining this fork to continue development.
+
+## Repository history
+
+The canonical URI of this project is <https://github.com/RIOT-OS/cosy/>;
+all recent mentions of issue numbers and pull requests refer to numbers in that repository.
+Issues and PRs mentioned before 2024 refer to numbers in <https://github.com/haukepetersen/cosy>.
+<!-- We would not have to do that if we used custom merge messages with full URIs
+as enabled through the output of https://github.com/orgs/community/discussions/5955 --
+but it is not in GitHub's interest to implement that. -->


### PR DESCRIPTION
Our merge commits following the standard GitHub template refer to unqualified numbers; users with a checkout have no means of making sense of those without a dated reference, which is provided here.

Those who perceive GitHub as a desirable hosting platform are cordially invited to give justification for why that statement needs to be in the README that is not passive aggressive; the present text is the best I can manage.